### PR TITLE
Fix TypeScript Strategy Action Types

### DIFF
--- a/yetify-backend/src/graphql/schemas/index.ts
+++ b/yetify-backend/src/graphql/schemas/index.ts
@@ -339,6 +339,8 @@ export const typeDefs = gql`
     PROVIDE_LIQUIDITY
     LEVERAGE
     BRIDGE
+    SWAP
+    WITHDRAW
   }
 
   enum ProtocolCategory {

--- a/yetify-backend/src/types/api-responses.ts
+++ b/yetify-backend/src/types/api-responses.ts
@@ -123,7 +123,7 @@ export interface Strategy {
 }
 
 export interface StrategyStep {
-  action: 'deposit' | 'stake' | 'yield_farm' | 'provide_liquidity' | 'leverage' | 'bridge';
+  action: 'deposit' | 'stake' | 'yield_farm' | 'provide_liquidity' | 'leverage' | 'bridge' | 'swap' | 'withdraw';
   protocol: string;
   asset: string;
   amount: string;


### PR DESCRIPTION
Add missing 'swap' and 'withdraw' action types to resolve compilation errors.

Closes #117